### PR TITLE
Add toggle button to hide/reveal morse text

### DIFF
--- a/data/ui/style.css
+++ b/data/ui/style.css
@@ -15,3 +15,12 @@
 #volume>scale trough slider {
   opacity: 0;
 }
+
+#receiving_text_view.hidden-text {
+  filter: blur(8px);
+}
+
+#receiving_text_view.hidden-text selection {
+  background-color: transparent;
+  color: transparent;
+}

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -222,6 +222,10 @@ template $MorseApplicationWindow: Adw.ApplicationWindow {
                       label: _("Generate Text");
                       icon-name: "dice-symbolic";
                     }
+                    ToggleButton toggle_text_button {
+                    styles ["circular", "osd"]
+                    icon-name: "view-conceal-symbolic";
+                  }
                   }
                 }
               };

--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -38,7 +38,7 @@ use adw::{
     Toast, ToastOverlay, prelude::*, subclass::prelude::*,
 };
 use gtk::{
-    Button, CheckButton, Grid, Label, Popover, TextBuffer, TextTag, TextView, gdk::Display, gio,
+    Button, CheckButton, Grid, Label, Popover, TextBuffer, TextTag, TextView, ToggleButton, gdk::Display, gio,
     glib,
 };
 
@@ -101,6 +101,8 @@ mod imp {
         copy_text_button: TemplateChild<Button>,
         #[template_child]
         generate_text_button: TemplateChild<Button>,
+        #[template_child]
+        toggle_text_button: TemplateChild<ToggleButton>,
         #[template_child]
         volume_control: TemplateChild<MorseVolumeControl>,
         pref_action: OnceCell<SimpleAction>,
@@ -568,7 +570,19 @@ mod imp {
                     }
                 }
             ));
-
+            self.toggle_text_button.connect_toggled(clone!(
+                #[weak(rename_to = this)]
+                self,
+                move |button| {
+                    if button.is_active() {
+                        button.set_icon_name("view-reveal-symbolic");
+                        this.text_view.add_css_class("hidden-text");
+                    } else {
+                        button.set_icon_name("view-conceal-symbolic");
+                        this.text_view.remove_css_class("hidden-text");
+                    }
+                }
+            ));
             // To change color of tag dependings on the accent color
             style_manager.connect_accent_color_rgba_notify(clone!(
                 #[weak]


### PR DESCRIPTION
I made this enhancement that makes it easier to test Morse reception skills without accidentally reading the generated text. When practicing Morse code reception, looking at the screen often gives away the letters being played. By blurring the text area during playback and-revealing it at the end, users can take self-evaluations and check their results.

## Normal
<img width="975" height="650" alt="image" src="https://github.com/user-attachments/assets/5e4323a7-c192-4dcc-b727-b92b6636ee74" />

## Blurred Text
<img width="975" height="650" alt="image" src="https://github.com/user-attachments/assets/d0f843dc-780a-40eb-a17f-e65167a1e15f" />
